### PR TITLE
Upload

### DIFF
--- a/pxl/cli.py
+++ b/pxl/cli.py
@@ -77,7 +77,7 @@ def upload_cmd(dir_name: str) -> None:
         if not entry.suffix.lower() in ['.jpeg', '.jpg']:
             continue
 
-        uuid = upload.as_public(pxl_config, entry)
+        uuid = upload.public_image(pxl_config, entry)
 
 
 def get_input(

--- a/pxl/cli.py
+++ b/pxl/cli.py
@@ -70,9 +70,20 @@ def upload_cmd(dir_name: str) -> None:
     album_name = get_input("What name should the album have? ({default}) ",
                            default=dir_path.name.title())
 
-    album = state.Album(name_display=album_name,
-                        name_nav=album_name.lower().replace(' ', '-'),
-                        images=[])
+    # Get existing album with this name for appending.
+    album = pxl_state.get_album_by_name(album_name)
+    if album:
+        append_confirm = get_input('Appending to existing album ok? [Y/n] ',
+                                   default='y',
+                                   validate=lambda x: x.lower() in ['y', 'n'])
+        if append_confirm == 'n':
+            print('Not appending. Choose a different album name.')
+            sys.exit(1)
+    else:
+        print('Creating new album.')
+        album = state.Album(name_display=album_name,
+                            name_nav=album_name.lower().replace(' ', '-'),
+                            images=[])
 
     # Find all files with known JPEG extensions. We don't
     # traverse nested directories, just the toplevel.
@@ -87,7 +98,7 @@ def upload_cmd(dir_name: str) -> None:
         image = state.Image(remote_uuid=uuid)
         album = album.add_image(image)
 
-    pxl_state = pxl_state.add_album(album)
+    pxl_state = pxl_state.add_or_replace_album(album)
     state.save_state(pxl_state)
 
 

--- a/pxl/cli.py
+++ b/pxl/cli.py
@@ -87,7 +87,8 @@ def upload_cmd(dir_name: str) -> None:
         image = state.Image(remote_uuid=uuid)
         album = album.add_image(image)
 
-    print(album)
+    pxl_state = pxl_state.add_album(album)
+    state.save_state(pxl_state)
 
 
 def get_input(

--- a/pxl/cli.py
+++ b/pxl/cli.py
@@ -67,6 +67,13 @@ def upload_cmd(dir_name: str) -> None:
     if not dir_path.is_dir():
         print(f'{dir_path} is not a directory.')
 
+    album_name = get_input("What name should the album have? ({default}) ",
+                           default=dir_path.name.title())
+
+    album = state.Album(name_display=album_name,
+                        name_nav=album_name.lower().replace(' ', '-'),
+                        images=[])
+
     # Find all files with known JPEG extensions. We don't
     # traverse nested directories, just the toplevel.
     for entry in dir_path.iterdir():
@@ -77,6 +84,10 @@ def upload_cmd(dir_name: str) -> None:
             continue
 
         uuid = upload.public_image(pxl_config, entry)
+        image = state.Image(remote_uuid=uuid)
+        album = album.add_image(image)
+
+    print(album)
 
 
 def get_input(

--- a/pxl/cli.py
+++ b/pxl/cli.py
@@ -1,10 +1,11 @@
 import click
 import getpass
-import pxl.state as state
 import sys
 
 from pathlib import Path
+from typing import Optional
 
+import pxl.state as state
 
 @click.group(name='pxl')
 def cli():
@@ -26,11 +27,11 @@ def init_cmd(force: bool):
     print('Defaults are between parentheses.')
     print()
 
-    s3_endpoint = input('S3 endpoint (digitaloceanspaces.com): ')
-    s3_region = input('S3 region (ams3): ')
-    s3_bucket = input('S3 bucket: ')
-    s3_key_id = input('S3 key ID: ')
-    s3_key_secret = getpass.getpass('S3 key secret (not echoed): ')
+    s3_endpoint = get_input('S3 endpoint ({default}): ', default='digitaloceanspaces.com')
+    s3_region = get_input('S3 region ({default}): ', default='ams3')
+    s3_bucket = get_input('S3 bucket: ')
+    s3_key_id = get_input('S3 key ID: ')
+    s3_key_secret = get_input('S3 key secret (not echoed): ', hide_input=True)
 
     config = state.Config(s3_endpoint,
                           s3_region,
@@ -69,6 +70,25 @@ def add_cmd(dir_name: str) -> None:
     print(str(album_name))
 
     # TODO: add new album to state. Upload. Regenerate index
+
+
+def get_input(
+        prompt: str,
+        default: Optional[str]=None,
+        hide_input: bool=False
+    ) -> str:
+    # Slightly magic behavior: if the default is set, we call the
+    # format method with the default on the string. This means the
+    # user is shown the default.
+    if default:
+        prompt = prompt.format(default=default)
+
+    user_input = getpass.getpass(prompt) if hide_input else input(prompt)
+
+    if user_input == '' and default:
+        return default
+
+    return user_input
 
 
 def main():

--- a/pxl/cli.py
+++ b/pxl/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 import pxl.state as state
+import pxl.upload as upload
 
 @click.group(name='pxl')
 def cli():
@@ -56,20 +57,27 @@ def clean_cmd(clean_config: bool):
 
 @cli.command(name='upload')
 @click.argument('dir_name')
-def add_cmd(dir_name: str) -> None:
+def upload_cmd(dir_name: str) -> None:
     """
     Upload a directory to the photo hosting.
     """
-    state.get_state_or_fail()
+    (pxl_state, pxl_config) = state.get_state_and_config_or_fail()
 
     dir_path = Path(dir_name)
     if not dir_path.is_dir():
         print(f'{dir_path} is not a directory.')
 
-    album_name = input('What name should the album have? ')
-    print(str(album_name))
+    # Find all files with known JPEG extensions. We don't
+    # traverse nested directories, just the toplevel.
+    for entry in dir_path.iterdir():
+        if not entry.is_file():
+            print('hi')
+            continue
 
-    # TODO: add new album to state. Upload. Regenerate index
+        if not entry.suffix.lower() in ['.jpeg', '.jpg']:
+            continue
+
+        uuid = upload.as_public(pxl_config, entry)
 
 
 def get_input(

--- a/pxl/state.py
+++ b/pxl/state.py
@@ -97,8 +97,17 @@ class Index:
             'albums': list(map(lambda album: album.to_json(), self.albums)),
         }
 
-    def add_album(self, album: Album) -> Index:
-        return Index(albums=self.albums + [album])
+    def add_or_replace_album(self, new_album: Album) -> Index:
+        albums = [album for album in self.albums
+                        if album.name_display != new_album.name_display]
+        return Index(albums=albums + [new_album])
+
+    def get_album_by_name(self, album_name: str) -> Optional[Album]:
+        for album in self.albums:
+            if album.name_display == album_name:
+                return album
+
+        return None
 
 
 @dataclass
@@ -116,8 +125,11 @@ class State:
     def to_json(self) -> Dict[str, Any]:
         return { 'index': Index.to_json(self.index) }
 
-    def add_album(self, album: Album) -> State:
-        return State(index=self.index.add_album(album))
+    def add_or_replace_album(self, album: Album) -> State:
+        return State(index=self.index.add_or_replace_album(album))
+
+    def get_album_by_name(self, album_name: str) -> Optional[Album]:
+        return self.index.get_album_by_name(album_name)
 
 
 def initialize(config: Config) -> None:

--- a/pxl/state.py
+++ b/pxl/state.py
@@ -64,6 +64,11 @@ class Album:
             'images': list(map(lambda image: image.to_json(), self.images)),
         }
 
+    def add_image(self, image: Image) -> Album:
+        return Album(images=self.images + [image],
+                     name_display=self.name_display,
+                     name_nav=self.name_nav)
+
 
 @dataclass
 class Index:

--- a/pxl/state.py
+++ b/pxl/state.py
@@ -43,10 +43,6 @@ class Config:
 
 @dataclass
 class Image:
-    # The local filename which this image is derived from.
-    # Optional: it's only populated when we add new photos to upload.
-    local_filename: Optional[Path]
-
     # The UUID derives the remote filename for the original, detail
     # and thumbnail versions of the image.
     remote_uuid: uuid.UUID
@@ -89,7 +85,6 @@ class State:
                 index=Index(
                     albums=[Album(
                             images=[Image(
-                                    local_filename = Path('sticky.png'),
                                     remote_uuid = uuid.uuid4()
                                 )],
                             name_display = "Foobar",

--- a/pxl/upload.py
+++ b/pxl/upload.py
@@ -1,0 +1,41 @@
+import uuid
+
+from enum import Enum
+from pathlib import Path
+from typing import Union
+
+import pxl.state as state
+
+
+def as_public(
+        config: state.Config,
+        local_filename: Path,
+    ) -> uuid.UUID:
+    """
+    Upload a local file as world readable with a random UUID.
+    """
+    file_uuid = uuid.uuid4()
+    extension = get_normalized_extension(local_filename)
+    object_name = f'{file_uuid}{extension}'
+    print(f'Uploading {local_filename} as {object_name}')
+    return file_uuid
+
+
+def as_private(
+        config: state.Config,
+        local_filename: Path,
+        object_name: str,
+    ) -> str:
+    """
+    Upload a local file as private under a given name. Returns
+    """
+    pass
+
+
+def get_normalized_extension(filename: Path) -> str:
+    suffix_lowered = filename.suffix.lower()
+
+    if suffix_lowered in ['.jpeg', '.jpg']:
+        return '.jpg'
+
+    return suffix_lowered


### PR DESCRIPTION
This PR adds upload logic for directories through the `pxl upload` command.

Features:

 - Uploads files to S3 with the right headers.
 - Remembers these uploads in the state file as albums
 - Logic for appending to an album if two names conflict
 - Normalizes an album for navigation