### PR TITLE
colors: Add draft for new colorscheme

### DIFF
--- a/design/css/photo.css
+++ b/design/css/photo.css
@@ -52,20 +52,19 @@
   top: 0px;
   width: 10%;
   height: 100vh;
-  background-color: rgba(186, 154, 135, 0.3);
+  background-color: var(--grey-main);
   z-index: 9999;
   text-decoration: none;
   display: flex;
   justify-content: center;
   align-items: center;
   font-size: 6rem;
-  color: var(--theme-light-blue);
-  text-shadow: 1px 2px rgba(0,0,0,0.4);
+  color: var(--grey-lightest);
   -webkit-transition: background-color 0.2s;
 }
 
 .nav:hover {
-  background-color: rgba(186, 154, 135, 0.7);
+  background-color: var(--grey-darkest);
 }
 
 

--- a/design/css/theme.css
+++ b/design/css/theme.css
@@ -1,8 +1,23 @@
 :root {
   --album-title-font: Verdana, Geneva, sans-serif;
-  --theme-light-blue: #6290c3;
-  --theme-dark-blue: #1a1b41;
-  --theme-sand: #f7edd7;
+
+  --prim-main: #45C4FB;
+  --prim-lightest: #9FE0FC;
+  --prim-light: #6FD1FC;
+  --prim-dark: #1BB5F8;
+  --prim-darkest: #06A8EE;
+
+  --sec-main: #FFA43E;
+  --sec-lightest: #FFD19D;
+  --sec-darkest: #FF8700;
+
+  --grey-main: #232627;
+  --grey-lightest: #373D3F;
+  --grey-light: #2C3031;
+  --grey-dark: #1F2324;
+  --grey-darkest: #161C1F;
+
+  --white: #fefefe;
 }
 
 body {


### PR DESCRIPTION
This adds a single `colors.html` file which contains our colorscheme. This file exists for review only. If we think this is nice, we can move this into the CSS

Reasoning:

 - Add primary and accent colors and utility shades.
 - Add white as our working color
 - Add some greys. All these contain a bit of our primary color. This means they work better than plain greys/blacks