### PR TITLE
Configurable base URL for images

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -22,6 +22,7 @@ a top level object from which `pxl` understands the following config keys:
  - `"deploy_host"`
  - `"deploy_user"`
  - `"deploy_path"`
+ - `"public_image_url"`
 
 You can write this file yourself, or you can use the setup wizard below. In
 case `pxl` ever gets new settings, it is probably good to know that this file
@@ -38,7 +39,8 @@ This is an example config file:
   "s3_key_secret": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "deploy_host": "svsticky.nl",
   "deploy_user": "pxl",
-  "deploy_path": "pxl-demo.svsticky.nl"
+  "deploy_path": "pxl-demo.svsticky.nl",
+  "public_image_url": "https://pxl-demo.ams3.cdn.digitaloceanspaces.com"
 }
 ```
 
@@ -64,6 +66,7 @@ S3 key secret (not shown):
 Deploy host: svsticky.nl
 Deploy user: pxl
 Deploy path: pxl-demo.svsticky.nl
+Public image base URL (optional) []: https://pxl-demo.ams3.cdn.digitaloceanspaces.com
 ```
 
  [docs-install]: /installation

--- a/pxl/cli.py
+++ b/pxl/cli.py
@@ -44,6 +44,8 @@ def init_cmd(force: bool) -> None:
     deploy_user = click.prompt("Deploy user")
     deploy_path = click.prompt("Deploy path")
 
+    public_image_url = click.prompt("Public image base URL (optional)", default="")
+
     cfg = config.Config(
         s3_endpoint,
         s3_region,
@@ -53,6 +55,7 @@ def init_cmd(force: bool) -> None:
         deploy_host,
         deploy_user,
         deploy_path,
+        public_image_url,
     )
 
     config.save(cfg)

--- a/pxl/cli.py
+++ b/pxl/cli.py
@@ -160,6 +160,7 @@ def build_cmd() -> None:
             output_dir=output_dir,
             template_dir=design_dir,
             bucket_puburl=bucket_puburl,
+            public_image_url=cfg.public_image_url,
         )
     click.echo("Done.", err=True)
 

--- a/pxl/config.py
+++ b/pxl/config.py
@@ -21,6 +21,7 @@ class Config:
     deploy_host: str
     deploy_user: str
     deploy_path: str
+    public_image_url: str
 
     def to_json(self) -> Dict[str, str]:
         return {
@@ -32,6 +33,7 @@ class Config:
             "deploy_host": self.deploy_host,
             "deploy_user": self.deploy_user,
             "deploy_path": self.deploy_path,
+            "public_image_url": self.public_image_url,
         }
 
     @classmethod
@@ -45,6 +47,7 @@ class Config:
             deploy_host=json["deploy_host"],
             deploy_user=json["deploy_user"],
             deploy_path=json["deploy_path"],
+            public_image_url=json.get("public_image_url", ""),
         )
 
 

--- a/pxl/generate.py
+++ b/pxl/generate.py
@@ -7,7 +7,11 @@ import pxl.state as state
 
 
 def build(
-    overview: state.Overview, output_dir: Path, template_dir: Path, bucket_puburl: str
+    overview: state.Overview,
+    output_dir: Path,
+    template_dir: Path,
+    bucket_puburl: str,
+    public_image_url: str,
 ) -> None:
     """Build a static site based on the state."""
 
@@ -22,15 +26,17 @@ def build(
     shutil.copytree(template_dir / "js", output_dir / "js")
     shutil.copy(template_dir / "404.html", output_dir / "404.html")
 
+    img_baseurl = public_image_url or bucket_puburl
+
     with (output_dir / "index.html").open("w+") as f:
-        index_template.stream(overview=overview, img_baseurl=bucket_puburl).dump(f)
+        index_template.stream(overview=overview, img_baseurl=img_baseurl).dump(f)
 
     for album in overview.albums:
         album_dir = output_dir / album.name_nav
         album_dir.mkdir()
 
         with (album_dir / "index.html").open("w+") as f:
-            album_template.stream(album=album, img_baseurl=bucket_puburl).dump(f)
+            album_template.stream(album=album, img_baseurl=img_baseurl).dump(f)
 
         for i, image in enumerate(album.images):
             image_dir = album_dir / str(image.remote_uuid)
@@ -46,7 +52,7 @@ def build(
                     img=image,
                     img_prev=img_prev,
                     img_next=img_next,
-                    img_baseurl=bucket_puburl,
+                    img_baseurl=img_baseurl,
                     album_name=album.name_nav,
                     title=title,
                 ).dump(f)


### PR DESCRIPTION
This PR adds a configuration option `public_image_url` to the config. This
option, if set to a nonempty string, will override the bucket URL as the source
where clients will load the images from, which can be for instance a CDN.

The value of this option should be a fully qualified URL. It should not end
with a trailing slash, although this might work.
Example value: `"https://pxl-demo.ams3.cdn.digitaloceanspaces.com"`

```json
{
  "…": "…",
  "public_image_url": "https://pxl-demo.ams3.cdn.digitaloceanspaces.com"
}
```

Fixes #47.