### PR TITLE
Ready for Review: added an cli option to delete an album with its pictures

### DIFF
--- a/pxl/state.py
+++ b/pxl/state.py
@@ -168,6 +168,14 @@ class Overview:
 
         return None
 
+    def remove_album(self, album_to_remove: Album) -> Overview:
+        albums = [
+            album
+            for album in self.albums
+            if album.name_display != album_to_remove.name_display
+        ]
+        return Overview(albums=albums)
+
     @classmethod
     def empty(cls) -> Overview:
         return cls(albums=[])

--- a/pxl/upload.py
+++ b/pxl/upload.py
@@ -150,3 +150,13 @@ def get_normalized_extension(filename: Path) -> str:
         return ".jpg"
 
     return suffix_lowered
+
+
+def delete_image(client: Client, filename: str) -> None:
+    """
+    Delete an image from the photo hosting.
+    """
+    client.boto.delete_objects(
+        Delete={"Objects": [{"Key": filename + ".jpg"}]}, Bucket=client.cfg.s3_bucket
+    )
+    print("deleted " + filename + ".jpg")


### PR DESCRIPTION
Status: Done, pls review

Added a command line option to remove an album, including its pictures.
Use `pxl delete "Album name"` to delete its pictures from the file hosting and remove the album from the state, in that order.
If the given album name does not match any known album the operation is cancelled.

Biggest drawback of this implementation is that the pictures are removed from the file hosting before the site is rebuild and deployed, leaving a window in which the album appears to have missing pictures.
The user is warned of this issue after the operation finishes.