### PR TITLE
More info for breaking locks

### DIFF
--- a/pxl/cli.py
+++ b/pxl/cli.py
@@ -132,14 +132,15 @@ def upload_cmd(dir_name: str, force: bool) -> None:
 
 
 @cli.command("build")
-def build_cmd() -> None:
+@click.option("--force", is_flag=True, type=bool, help="Force break lock")
+def build_cmd(force: bool) -> None:
     """Build a static site based on current state."""
     click.echo("Building site...", err=True)
     output_dir = Path.cwd() / "ignore" / "build"
     design_dir = Path.cwd() / "design"
 
     cfg = config.load()
-    with upload.client(cfg) as client:
+    with upload.client(cfg, break_lock=force) as client:
         try:
             pxl_state_json = upload.get_json(client, "state.json")
             overview = state.Overview.from_json(pxl_state_json)


### PR DESCRIPTION
This PR allows passing the `--force` flag to the `build` command to allow users to break the lock.
It also downloads the lockfile when an upload is attempted and found.

Example output:

```console
$ pipenv run pxl build
Building site...
Lock exists, aborting.
The state was locked by stef@Uitkijkpop on 2019-09-08 18:41:15.
Pass --force to ignore this.

$ pipenv run pxl build --force
Building site...
Breaking a lock set by stef@Uitkijkpop on 2019-09-08 18:41:15.
Done.

# No lock anymore
$ pipenv run pxl build --force
Building site...
Done.
```