### PR TITLE
cli: added edit command and date of album change option

### DIFF
--- a/design/index.html.j2
+++ b/design/index.html.j2
@@ -10,7 +10,7 @@
 </head>
 <body>
   <div class="albums">
-    {% for album in overview.albums|reverse %}
+    {% for album in overview.albums|sort(reverse=true, attribute="created") %}
     <a href="/{{ album.name_nav }}/" class="album">
       <img src="{{ img_baseurl }}/{{ album.images[0].get_name("thumbnail_w_400") }}.jpg"
            alt="{{ album.name_display }}" class="album-cover">

--- a/pxl/compress.py
+++ b/pxl/compress.py
@@ -56,6 +56,8 @@ def orient_exif(image: Any) -> Any:
     Rotate the image according to EXIF metadata.
     """
     exif_data = image._getexif()
+    if not(exif_data):
+        return image
 
     # EXIF metadata is a binary format. The magic number below stands for
     # the part of the metadata which all compliant software uses as the

--- a/pxl/state.py
+++ b/pxl/state.py
@@ -168,6 +168,15 @@ class Overview:
 
         return None
 
+    def edit_album(self, old_album, new_album):
+        albums = [
+            album
+            if album.name_display != old_album.name_display
+            else new_album
+            for album in self.albums
+        ]
+        return Overview(albums=albums)
+
     def remove_album(self, album_to_remove: Album) -> Overview:
         albums = [
             album


### PR DESCRIPTION
index.html.j2: Added sorting on date of album

You can now change the date of an album when uploading. Albums are sorted on this date, thus making it possible to maintain the order of activities in the overview.
An edit function is added as well, allowing the name and date of an album to be changed