### PR TITLE
cli: Changed empty folder check to jpg file check

### DIFF
--- a/pxl/cli.py
+++ b/pxl/cli.py
@@ -160,8 +160,8 @@ def upload_cmd(dir_name: str, force: bool) -> None:
         click.echo(f"{dir_path} is not a directory.", err=True)
         sys.exit(1)
 
-    if not (any(dir_path.iterdir())):
-        click.echo(f"{dir_path} is an empty folder.", err=True)
+    if not list(dir_path.glob("*.jpg")):
+        click.echo(f"{dir_path} does not contain any .jpg files.", err=True)
         sys.exit(1)
 
     with upload.client(cfg, break_lock=force) as client:


### PR DESCRIPTION
Pxl now checks if a folder you want to upload contains .jpg images instead of checking if a folder contains any files